### PR TITLE
Fix OnPlayerResurrect override signature for current AzerothCore

### DIFF
--- a/src/ChallengeModes.cpp
+++ b/src/ChallengeModes.cpp
@@ -445,7 +445,7 @@ public:
         killed->UpdatePlayerSetting("mod-challenge-modes", HARDCORE_DEAD, 1);
     }
 
-    void OnPlayerResurrect(Player* player, float /*restore_percent*/, bool /*applySickness*/) override
+    void OnPlayerResurrect(Player* player, float /*restore_percent*/, bool& /*applySickness*/) override
     {
         if (!sChallengeModes->challengeEnabledForPlayer(SETTING_HARDCORE, player))
         {
@@ -626,7 +626,7 @@ class ChallengeMode_IronMan : public ChallengeMode
 public:
     ChallengeMode_IronMan() : ChallengeMode("ChallengeMode_IronMan", SETTING_IRON_MAN) {}
 
-    void OnPlayerResurrect(Player* player, float /*restore_percent*/, bool /*applySickness*/) override
+    void OnPlayerResurrect(Player* player, float /*restore_percent*/, bool& /*applySickness*/) override
     {
         if (!sChallengeModes->challengeEnabledForPlayer(SETTING_IRON_MAN, player))
         {


### PR DESCRIPTION
This fixes compilation against current AzerothCore versions.

PlayerScript::OnPlayerResurrect now expects:
`bool& applySickness 
`
instead of:
`bool applySickness 
`

Without this adjustment the module fails to compile due to an invalid override signature.